### PR TITLE
Add missing require

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -2,6 +2,7 @@
 require "logstash/namespace"
 require "logstash/outputs/base"
 require "stud/buffer"
+require "json"
 
 # This output lets you output Metrics to InfluxDB
 #


### PR DESCRIPTION
Previously, I was getting the error:

```
{:timestamp=>"2015-03-08T12:45:41.759000+0000", :message=>"Failed to flush outgoing items", :outgoing_count=>56, :exception=>#<NoMethodError: undefined method `to_json' for #<Array:0x7b3ff5d0>>, :backtrace=>["/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-influxdb-0.1.3/lib/logstash/outputs/influxdb.rb:190:in `flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:219:in `buffer_flush'", "org/jruby/RubyHash.java:1341:in `each'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:216:in `buffer_flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:193:in `buffer_flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:112:in `buffer_initialize'", "org/jruby/RubyKernel.java:1507:in `loop'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:110:in `buffer_initialize'"], :level=>:warn}
```