### PR TITLE
Add sprintf formatting for column names in coerce_values.

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -64,7 +64,9 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
   # otherwise sprintf-filtered numeric values could get sent as strings
   # format is `{'column_name' => 'datatype'}`
   #
-  # currently supported datatypes are `integer` and `float`
+  # Currently supported datatypes are `integer` and `float`.
+  #
+  # Supports sprintf-formatting in column names.
   #
   config :coerce_values, :validate => :hash, :default => {}
 
@@ -132,6 +134,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       sprintf_points['time'] = event.timestamp.to_i
     end
     @coerce_values.each do |column, value_type|
+      column = event.sprintf(column)
       if sprintf_points.has_key?(column)
         begin
           case value_type


### PR DESCRIPTION
Fixes https://github.com/logstash-plugins/logstash-output-influxdb/issues/9 .