### PR TITLE
Fix data corruption when creating batches.

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -172,7 +172,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       begin
         if seen_series.has_key?(ev['name']) and (seen_series[ev['name']] == ev['columns'])
           @logger.info("Existing series data found. Appending points to that series")
-          event_collection.select {|h| h['points'] << ev['points'][0] if h['name'] == ev['name']}
+          event_collection.select {|h| h['points'] << ev['points'][0] if h['columns'] == ev['columns']}
         elsif seen_series.has_key?(ev['name']) and (seen_series[ev['name']] != ev['columns'])
           @logger.warn("Series '#{ev['name']}' has been seen but columns are different or in a different order. Adding to batch but not under existing series")
           @logger.warn("Existing series columns were: #{seen_series[ev['name']].join(",")} and event columns were: #{ev['columns'].join(",")}")


### PR DESCRIPTION
Previously, we were appending events to the event collection even when
the columns did not match!

Given the following three events:

```ruby
{
  "name": "my-series",
  "columns": [
    "cpu.user",
    "time"
  ],
  "points": [
    [
      5.0,
      1426288467
    ]
  ]
}
{
  "name": "my-series",
  "columns": [
    "memory.used",
    "time"
  ],
  "points": [
    [
      1000,
      1426288467
    ]
  ]
}
{
  "name": "my-series",
  "columns": [
    "cpu.user",
    "time"
  ],
  "points": [
    [
      6.0,
      1426288477
    ]
  ]
}
```

We would end up with the following batch:

```ruby
[
  {
    "name": "my-series",
    "columns": [
      "cpu.user",
      "time"
    ],
    "points": [
      [
        5.0,
        1426288467
      ],
      [
        6.0,
        1426288467
      ]
    ]
  },
  {
    "name": "my-series",
    "columns": [
      "memory.used",
      "time"
    ],
    "points": [
      [
        1000.0,
        1426288467
      ],
      [
        6.0, # this shouldn't be here!
        1426288467
      ]
    ]
  }
]