### PR TITLE
Adding missing required.

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -2,6 +2,7 @@
 require "logstash/namespace"
 require "logstash/outputs/base"
 require "stud/buffer"
+require "json"
 
 # This output lets you output Metrics to InfluxDB
 #


### PR DESCRIPTION
This causes "NoMethodError: undefined method `to_json' for #Array:0x4ec2e2a4" on the to_json call.