### PR TITLE
This makes this plugin stoppable as per the LS2.0 API

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -223,7 +223,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
     end
   end # def post
 
-  def teardown
+  def close
     buffer_flush(:final => true)
   end # def teardown
 end # class LogStash::Outputs::InfluxDB


### PR DESCRIPTION
Per https://github.com/elastic/logstash/issues/3963

I had to refactor the tests to not have a dependency on the pipeline, as this breaks with the logstash beta snapshots