### PR TITLE
Another InfluxDB 0.9 PR - Fix #31 & #32 + Previous PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.1.0
+ - New option to enable SSL/TLS encrypted communication to InfluxDB
+ - DB parameter now supports sprintf formatting
+
+## 3.0.0
+ - Update to work with influxdb 0.9
+ - breaking change, renaming 'series' to 'measurement'
+ - breaking change for values of time_precision
+ - Special characters now properly escaped in tag key/value, field key, measurement
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@ Contributors:
 * Kurt Hurtado (kurtado)
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
+* Michael Laws (mikelaws)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-influxdb'
-  s.version         = '3.0.0'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you output Metrics to InfluxDB"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/influxdb_spec.rb
+++ b/spec/outputs/influxdb_spec.rb
@@ -26,7 +26,8 @@ describe LogStash::Outputs::InfluxDB do
 
     before do
       subject.register
-      allow(subject).to receive(:post).with(result)
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:post).with(result, "statistics")
 
       2.times do
         subject.receive(LogStash::Event.new("foo" => "1", "bar" => "2", "time" => "3", "type" => "generator"))
@@ -39,7 +40,7 @@ describe LogStash::Outputs::InfluxDB do
     let(:result) { "logstash foo=\"1\",bar=\"2\" 3\nlogstash foo=\"1\",bar=\"2\" 3" }
 
     it "should receive 2 events, flush and call post with 2 items json array" do
-      expect(subject).to have_received(:post).with(result)
+      expect(subject).to have_received(:post).with(result, "statistics")
     end
 
   end
@@ -351,6 +352,156 @@ describe LogStash::Outputs::InfluxDB do
 
     it "should quote all other values (and escaping double quotes)" do
       expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
+      pipeline.run
+    end
+  end
+
+  # Test issue #32 - Add support for HTTPS via configuration
+  # --------------------------------------------------------
+  # A simple test to verify that setting the ssl configuration option works
+  # similar to other Logstash output plugins (specifically the Elasticsearch
+  # output plugin). 
+  context "setting the ssl configuration option to true" do
+    let(:config) do <<-CONFIG
+        input {
+           generator {
+             message => "foo=1 bar=2 baz=3 time=4"
+             count => 1
+             type => "generator"
+           }
+         }
+
+         filter {
+           kv { }
+         }
+
+         output {
+           influxdb {
+             host => "localhost"
+             ssl => true
+             measurement => "barfoo"
+             allow_time_override => true
+             use_event_fields_for_data_points => true
+             exclude_fields => [ "@version", "@timestamp", "sequence",
+                                 "message", "type", "host" ]
+           }
+         }
+      CONFIG
+    end
+
+    let(:expected_url)  { 'https://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p=' }
+    let(:expected_body) { 'barfoo foo="1",bar="2",baz="3" 4' }
+
+    it "should POST to an https URL" do
+      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
+      pipeline.run
+    end
+  end
+
+  # Test issue #31 - Run "db" parameter through event.sprintf() to support...
+  # -------------------------------------------------------------------------
+  # This test is intended to verify writes to multiple measurements in A SINGLE
+  # DATABASE continue to work *after* implementing #31.  Also verifies that
+  # sprintf formatting is supported in the measurement name.
+  context "receiving 3 points between 2 measurements in 1 database" do
+    let(:config) do <<-CONFIG
+        input {
+           generator {
+             lines => [
+               "foo=1 bar=2 baz=m1 time=1",
+               "foo=3 bar=4 baz=m2 time=2",
+               "foo=5 bar=6 baz=m2 time=3"
+             ]
+             count => 1
+             type => "generator"
+           }
+         }
+
+         filter {
+           kv { }
+         }
+
+         output {
+           influxdb {
+             host => "localhost"
+             db => "barfoo"
+             measurement => "%{baz}"
+             allow_time_override => true
+             use_event_fields_for_data_points => true
+             exclude_fields => [ "@version", "@timestamp", "sequence",
+                                 "message", "type", "host" ]
+           }
+         }
+      CONFIG
+    end
+
+    let(:expected_url)  { 'http://localhost:8086/write?db=barfoo&rp=default&precision=ms&u=&p=' }
+    let(:expected_body) { "m1 foo=\"1\",bar=\"2\",baz=\"m1\" 1\nm2 foo=\"3\",bar=\"4\",baz=\"m2\" 2\nm2 foo=\"5\",bar=\"6\",baz=\"m2\" 3" }
+
+    it "should result in a single POST (one per database)" do
+      expect_any_instance_of(Manticore::Client).to receive(:post!).once
+      pipeline.run
+    end
+
+    it "should POST in bulk format" do
+      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
+      pipeline.run
+    end
+  end
+
+  # Test issue #31 - Run "db" parameter through event.sprintf() to support...
+  # -------------------------------------------------------------------------
+  # This test is intended to verify writes to multiple measurements in MULTIPLE
+  # DATABASES result in separate bulk POSTs (one for each database in the
+  # buffer), and the correct measurements being written to the correct db.
+  # Also verifies that sprintf formatting is correctly supported in the
+  # database name.
+  context "receiving 4 points between 2 measurements in 2 databases" do
+    let(:config) do <<-CONFIG
+        input {
+           generator {
+             lines => [
+               "foo=1 bar=db1 baz=m1 time=1",
+               "foo=2 bar=db1 baz=m2 time=2",
+               "foo=3 bar=db2 baz=m1 time=3",
+               "foo=4 bar=db2 baz=m2 time=4"
+             ]
+             count => 1
+             type => "generator"
+           }
+         }
+
+         filter {
+           kv { }
+         }
+
+         output {
+           influxdb {
+             host => "localhost"
+             db => "%{bar}"
+             measurement => "%{baz}"
+             allow_time_override => true
+             use_event_fields_for_data_points => true
+             exclude_fields => [ "@version", "@timestamp", "sequence",
+                                 "message", "type", "host" ]
+           }
+         }
+      CONFIG
+    end
+
+    let(:expected_url_db1)  { 'http://localhost:8086/write?db=db1&rp=default&precision=ms&u=&p=' }
+    let(:expected_url_db2)  { 'http://localhost:8086/write?db=db2&rp=default&precision=ms&u=&p=' }
+    let(:expected_body_db1) { "m1 foo=\"1\",bar=\"db1\",baz=\"m1\" 1\nm2 foo=\"2\",bar=\"db1\",baz=\"m2\" 2" }
+    let(:expected_body_db2) { "m1 foo=\"3\",bar=\"db2\",baz=\"m1\" 3\nm2 foo=\"4\",bar=\"db2\",baz=\"m2\" 4" }
+
+    it "should result in two POSTs (one per database)" do
+      expect_any_instance_of(Manticore::Client).to receive(:post!).twice
+      pipeline.run
+    end
+
+    it "should post in bulk format" do
+      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url_db1, body: expected_body_db1)
+      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url_db2, body: expected_body_db2)
       pipeline.run
     end
   end


### PR DESCRIPTION
Sorry to muddy the InfluxDB 0.9 waters even more...  This PR includes fixes to address SSL/TLS support (http and https URLs - #32), and sprintf formatting in the DB name (#31).  This is based on a fork of the pr/29 branch (everything in pr #29 and addressing #24), with all of the great work from @contentfree and @timgriffiths (including your fixes for special character handling discussed in pr #30) merged in as well.

Tests have been added to validate SSL/TLS config handling, and proper handling/buffering/flushing of events destined for a single, and multiple databases (via sprintf formatting in the configuration).  Also added a test that exercises sprintf formatting in the "measurement" name.  These are in addition to @timgriffiths tests, which appear to provide good coverage for his special character handling fixes and run fine in my environment.

Signed the CLA about a week ago.  Currently running against InfluxDB 0.9.6, but should work against any 0.9 release, and should also be forward-compatible with InfluxDB 0.10.x.

If we can get a quick thumbs-up on the latest code changes, perhaps we can get this plugin moving forward and close several PRs and issues in the process.  I see that @jordansissel has reviewed some of the earlier code changes, and suggested the bump in major version, which makes sense to me given the breaking changes and new features/fixes.