### PR TITLE
Add check for boolean in quoted

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -339,7 +339,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
 
   # Return a quoted string of the given value if it's not a number
   def quoted(value)
-    Numeric === value ? value : %Q|"#{value.gsub('"','\"')}"|
+    Numeric === value || !!value == value ? value : %Q|"#{value.gsub('"','\"')}"|
   end
 
 


### PR DESCRIPTION
Solves an issue when the value passed in turns out to be a boolean

Failed to flush outgoing items {:outgoing_count=>69, :exception=>"NoMethodError", :backtrace=>[

"/.../logstash-2.3.1/vendor/bundle/jruby/1.9/gems/logstash-output-influxdb-3.1.2/lib/logstash/outputs/influxdb.rb:342:in `quoted'", 
     ..... rest of stacktrace...
