### PR TITLE
Update influxdb.rb

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -148,9 +148,6 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       end
     end
 
-    exclude_fields!(point)
-    coerce_values!(point)
-
     tags, point = extract_tags(point)
 
     event_hash = {
@@ -158,6 +155,9 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       "time"        => time,
       "fields"      => point
     }
+    exclude_fields!(point)
+    coerce_values!(point)
+
     event_hash["tags"] = tags unless tags.empty?
 
     buffer_receive(event_hash, event.sprintf(@db))


### PR DESCRIPTION
To add ability use event fields as tags and @measurement and remove them after, not before extract_tags call. For efficective DB space management.

For example:

influxdb{
 send_as_tags => ["host","name","startaddr","state","vpnname"]
 measurement => "%{schema}"
 retention_policy => autogen
 use_event_fields_for_data_points => true
 host => "localhost"
 db => "ggsn"
 time_precision => "s"
 exclude_fields => ["@version","@timestamp","type","sequence","schema","host","name","startaddr","state","vpnname"]
}
