### PR TITLE
Set extract_tags call prior exclude_fields

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -148,9 +148,6 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       end
     end
 
-    exclude_fields!(point)
-    coerce_values!(point)
-
     tags, point = extract_tags(point)
 
     event_hash = {
@@ -158,6 +155,8 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
       "time"        => time,
       "fields"      => point
     }
+    exclude_fields!(point)
+    coerce_values!(point)
     event_hash["tags"] = tags unless tags.empty?
 
     buffer_receive(event_hash, event.sprintf(@db))

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'
   s.add_development_dependency 'logstash-filter-kv'
+  s.add_development_dependency 'logstash-filter-mutate'
 end
 

--- a/spec/outputs/influxdb_spec.rb
+++ b/spec/outputs/influxdb_spec.rb
@@ -58,6 +58,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -66,7 +69,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my_series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
            }
          }
       CONFIG
@@ -93,6 +96,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -101,7 +107,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my_series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              send_as_tags => ["bar", "baz", "qux"]
            }
          }
@@ -135,6 +141,9 @@ describe LogStash::Outputs::InfluxDB do
 		"feild space" => "pink dog"
 	      }
 	   }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -143,7 +152,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              send_as_tags => ["bar", "baz", "test1", "test space"]
            }
          }
@@ -177,6 +186,9 @@ describe LogStash::Outputs::InfluxDB do
                 "feild, space" => "pink, dog"
               }
            }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -185,7 +197,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my, series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              send_as_tags => ["bar", "baz", "test1", "test, space"]
            }
          }
@@ -219,6 +231,9 @@ describe LogStash::Outputs::InfluxDB do
                 "feild= space" => "pink= dog"
               }
            }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -227,7 +242,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my=series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              send_as_tags => ["bar", "baz", "test1", "test=space"]
            }
          }
@@ -261,6 +276,9 @@ describe LogStash::Outputs::InfluxDB do
                 "feildspace" => 'C:\\Griffo'
               }
            }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -269,7 +287,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => 'my\\series'
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              send_as_tags => ['bar', "baz", "test1", "test=space"]
            }
          }
@@ -298,6 +316,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { add_tag => [ "tagged" ] }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -306,7 +327,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my_series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
            }
          }
       CONFIG
@@ -333,6 +354,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -341,7 +365,7 @@ describe LogStash::Outputs::InfluxDB do
              measurement => "my_series"
              allow_time_override => true
              use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
+             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type"]
              coerce_values => { "foo" => "integer" "bar" => "float" }
            }
          }
@@ -374,6 +398,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -384,7 +411,7 @@ describe LogStash::Outputs::InfluxDB do
              allow_time_override => true
              use_event_fields_for_data_points => true
              exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
+                                 "message", "type"]
            }
          }
       CONFIG
@@ -420,6 +447,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -430,7 +460,7 @@ describe LogStash::Outputs::InfluxDB do
              allow_time_override => true
              use_event_fields_for_data_points => true
              exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
+                                 "message", "type"]
            }
          }
       CONFIG
@@ -474,6 +504,9 @@ describe LogStash::Outputs::InfluxDB do
 
          filter {
            kv { }
+	   mutate {
+	    remove_field => ["host"]
+	   }
          }
 
          output {
@@ -484,7 +517,7 @@ describe LogStash::Outputs::InfluxDB do
              allow_time_override => true
              use_event_fields_for_data_points => true
              exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
+                                 "message", "type"]
            }
          }
       CONFIG


### PR DESCRIPTION
Hi! 
Propose to set extract_tags call prior exclude_fields, coz in case of needs of pull tags from already existent filelds its deleted before plugin can store it in tags. If not to change it this tags will store in influxdb twice: as tags and as extra fields.
What to commit:
- set extract_tags call prior exclude_fields (also @measurement)
- add mutate clause to be able remove "host" from exclude_fields in test pipeline, coz it somewhat a workaround near host=testing-worker-linux-docker-85c5f992-3430-linux-14
- add mutate to development dependencies

