### PR TITLE
Use ruby client

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -125,10 +125,8 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
 
   public
   def register
-    require 'manticore'
     require 'cgi'
     
-    @client = Manticore::Client.new
     @queue = []
 
     buffer_initialize(

--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -187,7 +187,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
     
   def dowrite(events, database)
     begin
-        @influxdbClient.write_points(events, nil, @retention_policy, @db  )
+        @influxdbClient.write_points(events, @time_precision, @retention_policy, @db  )
     rescue InfluxDB::AuthenticationError => ae
         @logger.warn("Authentication Error while writing to InfluxDB", :exception => ae)
     rescue InfluxDB::ConnectionError => ce 

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'manticore'
+  s.add_runtime_dependency 'influxdb'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'manticore'
-  s.add_runtime_dependency 'influxdb'
+  s.add_runtime_dependency 'influxdb' , ">= 0.3", "<= 0.3.99"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'

--- a/spec/outputs/influxdb_spec.rb
+++ b/spec/outputs/influxdb_spec.rb
@@ -1,34 +1,98 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/influxdb"
-require "manticore"
 
 describe LogStash::Outputs::InfluxDB do
 
-  let(:pipeline) { LogStash::Pipeline.new(config) }
+  subject { LogStash::Outputs::InfluxDB.new(config) }
+    
+  context "validate minimal default config" do
 
+    let(:config) do
+    {
+      "host" => "testhost",
+      "use_event_fields_for_data_points" => true
+    }
+    end
+
+    before do
+      subject.register
+      subject.close
+    end
+
+    it "sets correct influx client settings" do
+
+      config = subject.instance_variable_get(:@influxdbClient).config
+
+      expect(config.next_host).to eq "testhost"  
+      expect(config.instance_variable_get(:@port)).to eq 8086 
+      expect(config.instance_variable_get(:@time_precision)).to eq "ms" 
+      expect(config.instance_variable_get(:@auth_method)).to eq "none".freeze 
+      expect(config.instance_variable_get(:@initial_delay)).to eq 1
+      expect(config.instance_variable_get(:@retry)).to eq 3
+      expect(config.instance_variable_get(:@use_ssl)).to eq false
+      expect(config.instance_variable_get(:@username)).to eq nil 
+      expect(config.instance_variable_get(:@password)).to eq nil 
+
+    end
+
+  end
+
+  context "validate non default config" do
+
+    let(:config) do
+    {
+      "host" => "localhost",
+      "use_event_fields_for_data_points" => true,
+      "port" => 9999,
+      "ssl" => true,
+      "user" => "my_user",
+      "password" => "my_pass",
+      "initial_delay" => 5,
+      "max_retries" => 8,
+      "time_precision" => "s"
+    }
+    end
+
+    before do
+      subject.register
+      subject.close
+    end
+
+    it "sets correct influx client settings" do
+      config = subject.instance_variable_get(:@influxdbClient).config
+      expect(config.instance_variable_get(:@port)).to eq 9999
+      expect(config.instance_variable_get(:@time_precision)).to eq "s"   
+      expect(config.instance_variable_get(:@initial_delay)).to eq 5
+      expect(config.instance_variable_get(:@retry)).to eq 8
+      expect(config.instance_variable_get(:@use_ssl)).to eq true    
+      expect(config.instance_variable_get(:@username)).to eq "my_user"
+      expect(config.instance_variable_get(:@password)).to eq "my_pass"  
+      expect(config.instance_variable_get(:@auth_method)).to eq "params".freeze           
+    end
+
+  end
+  
   context "complete pipeline run with 2 events" do
 
     let(:config) do
-      {
-        "host" => "localhost",
-        "user" => "someuser",
-        "password" => "somepwd",
-        "allow_time_override" => true,
-        "data_points" => {
-          "foo" => "%{foo}",
-          "bar" => "%{bar}",
-          "time" => "%{time}"
-        }
+    {
+      "host" => "localhost",
+      "user" => "someuser",
+      "password" => "somepwd",
+      "allow_time_override" => true,
+      "data_points" => {
+        "foo" => "%{foo}",
+        "bar" => "%{bar}",
+        "time" => "%{time}"
       }
+    }
     end
-
-    subject { LogStash::Outputs::InfluxDB.new(config) }
 
     before do
       subject.register
       # Added db name parameter to post - M.Laws
-      allow(subject).to receive(:post).with(result, "statistics")
+      allow(subject).to receive(:dowrite).with(result, "statistics")
 
       2.times do
         subject.receive(LogStash::Event.new("foo" => "1", "bar" => "2", "time" => "3", "type" => "generator"))
@@ -38,365 +102,138 @@ describe LogStash::Outputs::InfluxDB do
       subject.close
     end
 
-    let(:result) { "logstash foo=\"1\",bar=\"2\" 3\nlogstash foo=\"1\",bar=\"2\" 3" }
+    #let(:result) { "logstash foo=\"1\",bar=\"2\" 3\nlogstash foo=\"1\",bar=\"2\" 3" }
+
+    let(:result) {[{:series=>"logstash", :timestamp=>"3", :values=>{"foo"=>"1", "bar"=>"2"}}, {:series=>"logstash", :timestamp=>"3", :values=>{"foo"=>"1", "bar"=>"2"}}]}
 
     it "should receive 2 events, flush and call post with 2 items json array" do
-      expect(subject).to have_received(:post).with(result, "statistics")
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
     end
 
   end
 
   context "using event fields as data points" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 time=3"
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my_series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "my_series",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true
+    }
     end
 
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my_series bar="2",foo="1" 3' }
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite).with(result, "statistics")
+
+      subject.receive(LogStash::Event.new("foo" => "1", "bar" => "2", "time" => "3", "type" => "generator"))
+
+      # Close / flush the buffer
+      subject.close
+    end
+
+    let(:result) {[{:series=>"my_series", :timestamp=>"3", :values=>{"foo"=>"1", "bar"=>"2"}}]}
 
     it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
     end
+
   end
+
 
   context "sending some fields as Influxdb tags" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=3 time=4"
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my_series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             send_as_tags => ["bar", "baz", "qux"]
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "my_series",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true,
+      "send_as_tags" => ["bar", "baz", "qux"]
+    }
     end
 
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my_series,bar=2,baz=3 foo="1" 4' }
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite).with(result, "statistics")
 
-    it "should send the specified fields as tags" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
+      subject.receive(LogStash::Event.new("foo" => "1", "bar" => "2", "baz" => "3", "time" => "4", "type" => "generator"))
+
+      # Close / flush the buffer
+      subject.close
     end
+
+    let(:result) {[{:series=>"my_series", :timestamp=>"4", :tags=>{"bar"=>"2", "baz"=>"3"}, :values=>{"foo"=>"1"}}]}
+
+    it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
+    end
+
   end
-
-  context "Escapeing space characters" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=3 time=4"
-             count => 1
-             type => "generator"
-           }
-         }
-
-         filter {
-           kv { 
-	      add_field => {
-		"test1" => "yellow cat"
-		"test space" => "making life hard"
-		"feild space" => "pink dog"
-	      }
-	   }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             send_as_tags => ["bar", "baz", "test1", "test space"]
-           }
-         }
-      CONFIG
-    end
-
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my\ series,bar=2,baz=3,test1=yellow\ cat,test\ space=making\ life\ hard foo="1",feild\ space="pink dog" 4' }
-
-    it "should send the specified fields as tags" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
-    end
-  end
-
-  context "Escapeing comma characters" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=3 time=4"
-             count => 1
-             type => "generator"
-           }
-         }
-
-         filter {
-           kv {
-              add_field => {
-                "test1" => "yellow, cat"
-                "test, space" => "making, life, hard"
-                "feild, space" => "pink, dog"
-              }
-           }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my, series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             send_as_tags => ["bar", "baz", "test1", "test, space"]
-           }
-         }
-      CONFIG
-    end
-
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my\,\ series,bar=2,baz=3,test1=yellow\,\ cat,test\,\ space=making\,\ life\,\ hard foo="1",feild\,\ space="pink, dog" 4' }
-
-    it "should send the specified fields as tags" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
-    end
-  end
-
-  context "Escapeing equal characters" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=3 time=4"
-             count => 1
-             type => "generator"
-           }
-         }
-
-         filter {
-           kv {
-              add_field => {
-                "test1" => "yellow=cat"
-                "test=space" => "making= life=hard"
-                "feild= space" => "pink= dog"
-              }
-           }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my=series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             send_as_tags => ["bar", "baz", "test1", "test=space"]
-           }
-         }
-      CONFIG
-    end
-
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my=series,bar=2,baz=3,test1=yellow\=cat,test\=space=making\=\ life\=hard foo="1",feild\=\ space="pink= dog" 4' }
-
-    it "should send the specified fields as tags" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
-    end
-  end
-
-  context "testing backslash characters" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => 'foo\\=1 bar=2 baz=3 time=4'
-             count => 1
-             type => "generator"
-           }
-         }
-
-         filter {
-           kv {
-              add_field => {
-                "test1" => "yellow=cat"
-                "test=space" => "making=, life=hard"
-                "feildspace" => 'C:\\Griffo'
-              }
-           }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => 'my\\series'
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             send_as_tags => ['bar', "baz", "test1", "test=space"]
-           }
-         }
-      CONFIG
-    end
-
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my\series,bar=2,baz=3,test1=yellow\=cat,test\=space=making\=\,\ life\=hard foo\="1",feildspace="C:\Griffo" 4' }
-
-    it "should send the specified fields as tags" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
-    end
-  end
-
 
   context "when fields data contains a list of tags" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 time=2"
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { add_tag => [ "tagged" ] }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my_series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "my_series",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true,
+    }
     end
 
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my_series,tagged=true foo="1" 2' }
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite).with(result, "statistics")
 
-    it "should move them to the tags data" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
+      subject.receive(event)
+
+      # Close / flush the buffer
+      subject.close
     end
+    
+    let(:event) {LogStash::Event.new("foo" => "1", "time" => "2", "tags" => ["tagged"], "type" => "generator")}
+    let(:result) {[{:series=>"my_series", :timestamp=>"2", :tags=>{"tagged"=>"true"}, :values=>{"foo"=>"1"}}]}
+
+    it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
+    end
+
   end
 
   context "when fields are coerced to numerics" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=\\\"quotes\\\" time=3"
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             measurement => "my_series"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => ["@version", "@timestamp", "sequence", "message", "type", "host"]
-             coerce_values => { "foo" => "integer" "bar" => "float" }
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "my_series",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true,
+      "coerce_values" => { "foo" => "integer", "bar" => "float" }
+    }
     end
 
-    let(:expected_url)  { 'http://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p='}
-    let(:expected_body) { 'my_series bar=2.0,foo=1,baz="\\\"quotes\\\"" 3' } # We want the backslash and the escaped-quote in the request body
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite).with(result, "statistics")
 
-    it "should quote all other values (and escaping double quotes)" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
-    end
-  end
+      subject.receive(LogStash::Event.new("foo" => "1", "bar" => "2.0", "baz"=>"\\\"quotes\\\"", "time"=>3, "type" => "generator"))
 
-  # Test issue #32 - Add support for HTTPS via configuration
-  # --------------------------------------------------------
-  # A simple test to verify that setting the ssl configuration option works
-  # similar to other Logstash output plugins (specifically the Elasticsearch
-  # output plugin). 
-  context "setting the ssl configuration option to true" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             message => "foo=1 bar=2 baz=3 time=4"
-             count => 1
-             type => "generator"
-           }
-         }
-
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             ssl => true
-             measurement => "barfoo"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
-           }
-         }
-      CONFIG
+      # Close / flush the buffer
+    subject.close
     end
 
-    let(:expected_url)  { 'https://localhost:8086/write?db=statistics&rp=default&precision=ms&u=&p=' }
-    let(:expected_body) { 'barfoo bar="2",foo="1",baz="3" 4' }
+    let(:result) {[{:series=>"my_series", :timestamp=>3, :values=>{"foo"=>1, "bar"=>2.0, "baz"=>"\\\"quotes\\\"" }}]}
 
-    it "should POST to an https URL" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
+    it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
     end
+
   end
 
   # Test issue #31 - Run "db" parameter through event.sprintf() to support...
@@ -405,49 +242,35 @@ describe LogStash::Outputs::InfluxDB do
   # DATABASE continue to work *after* implementing #31.  Also verifies that
   # sprintf formatting is supported in the measurement name.
   context "receiving 3 points between 2 measurements in 1 database" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             lines => [
-               "foo=1 bar=2 baz=m1 time=1",
-               "foo=3 bar=4 baz=m2 time=2",
-               "foo=5 bar=6 baz=m2 time=3"
-             ]
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             db => "barfoo"
-             measurement => "%{baz}"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "%{baz}",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true
+    }
     end
 
-    let(:expected_url)  { 'http://localhost:8086/write?db=barfoo&rp=default&precision=ms&u=&p=' }
-    let(:expected_body) { "m1 bar=\"2\",foo=\"1\",baz=\"m1\" 1\nm2 bar=\"4\",foo=\"3\",baz=\"m2\" 2\nm2 bar=\"6\",foo=\"5\",baz=\"m2\" 3" }
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite)
 
-    it "should result in a single POST (one per database)" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).once
-      pipeline.run
+      subject.receive(LogStash::Event.new("foo"=>"1", "bar"=>"2", "baz" => "m1", "time" => "1", "type" => "generator"))
+      subject.receive(LogStash::Event.new("foo"=>"3", "bar"=>"4", "baz" => "m2", "time" => "2", "type" => "generator"))
+      subject.receive(LogStash::Event.new("foo"=>"5", "bar"=>"6", "baz" => "m2", "time" => "3", "type" => "generator"))
+
+      # Close / flush the buffer
+      subject.close
     end
 
-    it "should POST in bulk format" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url, body: expected_body)
-      pipeline.run
+    let(:result) {[{:series=>"m1", :timestamp=>"1", :values=>{"foo"=>"1", "bar"=>"2", "baz" => "m1" }},{:series=>"m2", :timestamp=>"2", :values=>{"foo"=>"3", "bar"=>"4", "baz" => "m2"}},{:series=>"m2", :timestamp=>"3", :values=>{"foo"=>"5", "bar"=>"6", "baz" => "m2" }}]}
+
+    it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
     end
+
   end
 
   # Test issue #31 - Run "db" parameter through event.sprintf() to support...
@@ -458,52 +281,38 @@ describe LogStash::Outputs::InfluxDB do
   # Also verifies that sprintf formatting is correctly supported in the
   # database name.
   context "receiving 4 points between 2 measurements in 2 databases" do
-    let(:config) do <<-CONFIG
-        input {
-           generator {
-             lines => [
-               "foo=1 bar=db1 baz=m1 time=1",
-               "foo=2 bar=db1 baz=m2 time=2",
-               "foo=3 bar=db2 baz=m1 time=3",
-               "foo=4 bar=db2 baz=m2 time=4"
-             ]
-             count => 1
-             type => "generator"
-           }
-         }
 
-         filter {
-           kv { }
-         }
-
-         output {
-           influxdb {
-             host => "localhost"
-             db => "%{bar}"
-             measurement => "%{baz}"
-             allow_time_override => true
-             use_event_fields_for_data_points => true
-             exclude_fields => [ "@version", "@timestamp", "sequence",
-                                 "message", "type", "host" ]
-           }
-         }
-      CONFIG
+    let(:config) do
+    {
+      "host" => "localhost",
+      "db" => "%{bar}",
+      "measurement" => "%{baz}",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true,
+    }
     end
 
-    let(:expected_url_db1)  { 'http://localhost:8086/write?db=db1&rp=default&precision=ms&u=&p=' }
-    let(:expected_url_db2)  { 'http://localhost:8086/write?db=db2&rp=default&precision=ms&u=&p=' }
-    let(:expected_body_db1) { "m1 bar=\"db1\",foo=\"1\",baz=\"m1\" 1\nm2 bar=\"db1\",foo=\"2\",baz=\"m2\" 2" }
-    let(:expected_body_db2) { "m1 bar=\"db2\",foo=\"3\",baz=\"m1\" 3\nm2 bar=\"db2\",foo=\"4\",baz=\"m2\" 4" }
+    before do
+      subject.register
+      # Added db name parameter to post - M.Laws
+      allow(subject).to receive(:dowrite)
 
-    it "should result in two POSTs (one per database)" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).twice
-      pipeline.run
+      subject.receive(LogStash::Event.new("foo"=>"1", "bar"=>"db1", "baz" => "m1", "time" => "1", "type" => "generator"))
+      subject.receive(LogStash::Event.new("foo"=>"2", "bar"=>"db1", "baz" => "m1", "time" => "2", "type" => "generator"))
+      subject.receive(LogStash::Event.new("foo"=>"3", "bar"=>"db2", "baz" => "m2", "time" => "3", "type" => "generator"))
+      subject.receive(LogStash::Event.new("foo"=>"4", "bar"=>"db2", "baz" => "m2", "time" => "4", "type" => "generator"))
+      # Close / flush the buffer
+      subject.close
     end
 
-    it "should post in bulk format" do
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url_db1, body: expected_body_db1)
-      expect_any_instance_of(Manticore::Client).to receive(:post!).with(expected_url_db2, body: expected_body_db2)
-      pipeline.run
+    let(:resultdb1) {[{:series=>"m1", :timestamp=>"1", :values=>{"foo"=>"1", "bar"=>"db1", "baz" => "m1" }},{:series=>"m1", :timestamp=>"2", :values=>{"foo"=>"2", "bar"=>"db1", "baz" => "m1" }}]}
+    let(:resultdb2) {[{:series=>"m2", :timestamp=>"3", :values=>{"foo"=>"3", "bar"=>"db2", "baz" => "m2" }},{:series=>"m2", :timestamp=>"4", :values=>{"foo"=>"4", "bar"=>"db2", "baz" => "m2" }}]}
+
+    it "should use the event fields as the data points, excluding @version and @timestamp by default as well as any fields configured by exclude_fields" do
+      expect(subject).to have_received(:dowrite).with(resultdb1, "db1").once
+      expect(subject).to have_received(:dowrite).with(resultdb2, "db2").once
     end
+
+
   end
 end


### PR DESCRIPTION
Replaces the custom HTTP code with the official influxdb ruby client. Although I am confident there shouldn't be many breaking changes (aside from known one detailed below) this a large change so perhaps a separate branch might be best initially? 

The primary motivation for this was to incorporate the inbuild retry and exponential back-off functionality of the influx ruby client, but as a nice side effect it will also allow the plugin to support the integer and boolean data types for influxdb when use_event_fields_for_data_points = true.

This PR adds two new config options
**initial_delay**: The amount of time in seconds to delay the initial retry on connection / transient failures.  
**max_retries**:  The number of time to retry recoverable errors before dropping the events. As per the influx ruby client funcationality -1 is will result in infinite retries, 0 will mean no retries are attempted.

Using the influx ruby client also simplifies the existing codebase as the character escaping code within the plugin is no longer required because the influxdb ruby client handles all of this.

Existing user/pass authentication and ssl options have been tested and are working as before. 

No changes have been made to any of the field transformation functionality.

**Known breaking change** 

When use_event_fields_for_data_points is true, the previous version of the plugin would send only strings and float values. By changing to the influx ruby client it will send integer fields as the correct type instead of as a float. 

Other potential bug fixes 
Using the official ruby client will also enable bool values to be written correctly to influxdb which is currently broken see #45

As per #53 have updated the default to be "autogen" instead of "default" in line with the last few influxdb releases.

I believe this PR should also help resolve stability issues such as 
#14
#18
#52

Overlapping Pull requests 
#15
#39

Tested with a few versions of influx db between 0.11 up to the latest 1.2, the influxdb client should support any version from 0.9 upwards.




