### PR TITLE
Fix typo in exception handling

### DIFF
--- a/lib/logstash/outputs/influxdb.rb
+++ b/lib/logstash/outputs/influxdb.rb
@@ -191,7 +191,7 @@ class LogStash::Outputs::InfluxDB < LogStash::Outputs::Base
     rescue InfluxDB::ConnectionError => ce 
         @logger.warn("Connection Error while writing to InfluxDB", :exception => ce)
     rescue Exception => e
-        @logger.warn("Non recoverable exception while writing to InfluxDB", :exception => ce)
+        @logger.warn("Non recoverable exception while writing to InfluxDB", :exception => e)
     end
   end
 


### PR DESCRIPTION
Hi! After trying to understand the problem I was having in my app for a while, I noticed there is a typo in one of the exception handlers. This might confuse people when some unexpected exception occurs.

Nice work guys, I hope you can continue supporting this library.