### PR TITLE
Retrospectively add 5.0.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## 5.0.2
   - Fix some documentation issues
+  
+## 5.0.1
+  - Fix a typo in exception handling 
+  - Various build and ci changes
 
 ## 5.0.0 
  - Use the official influxdb client. This doesn't change the config options, but has some


### PR DESCRIPTION
I noticed that there was a missing hotfix version which had a code change not in the changelog. 

Only code change I can see:
https://github.com/logstash-plugins/logstash-output-influxdb/commit/625ef6deda7d3016059b04df723c2b5c815f3cb6
Rest commits are:
https://github.com/logstash-plugins/logstash-output-influxdb/commit/250d7fb21a3a122b9b972459512a274169a90326
https://github.com/logstash-plugins/logstash-output-influxdb/commit/064c10942fb9430c1b1ec71ebb788f73e754847d
https://github.com/logstash-plugins/logstash-output-influxdb/commit/dd7984d03b39127c6bfe8d0e33f385b7be753fb3
https://github.com/logstash-plugins/logstash-output-influxdb/commit/22aee1ddac86a6e239f0113ef8998d5d0755be86
https://github.com/logstash-plugins/logstash-output-influxdb/commit/7ccc9fe195bc319ac5c2462227848622faf4c93f

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
