### PR TITLE
Add missing documentation for send_as_tags

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -229,7 +229,8 @@ The retention policy to use
 
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
-request should be considered metadata and given as tags.
+request should be considered metadata and given as tags. Tags are only send when
+present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -229,7 +229,7 @@ The retention policy to use
 
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
-request should be considered metadata and given as tags. Tags are only send when
+request should be considered metadata and given as tags. Tags are only sent when
 present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
 
 [id="plugins-{type}s-{plugin}-ssl"]


### PR DESCRIPTION
The inline documentation for the code states that tags are only send if they are also defined in data_points, this part is missing here. (merged in #38)

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
