### PR TITLE
Bump version in gemspec and changelog for doc change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.5
+  - Added clarifying information for `send_as_tags` config option [#80](https://github.com/logstash-plugins/logstash-output-influxdb/pull/80)
+  
 ## 5.0.4
   - Docs: Set the default_codec doc attribute.
 

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-influxdb'
-  s.version         = '5.0.4'
+  s.version         = '5.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes metrics to InfluxDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Update version in gemspec and changelog to trigger doc build to pick up changes introduced in #80.
