### PR TITLE
Add support for canonical event field names for data-points/tags

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,9 +55,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retention_policy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-send_as_tags>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-send_array_field_as_tags>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-time_precision>> |<<string,string>>, one of `["n", "u", "ms", "s", "m", "h"]`|No
 | <<plugins-{type}s-{plugin}-use_event_fields_for_data_points>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_hash_field_for_data_points>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
 
@@ -230,8 +232,20 @@ The retention policy to use
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
 request should be considered metadata and given as tags. Tags are only sent when
-present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
+present in `data_points` or if `use_hash_field_for_data_points` is specified 
+or if `use_event_fields_for_data_points` is `true`.
 
+[id="plugins-{type}s-{plugin}-send_array_field_as_tags"]
+===== `send_array_field_as_tags` 
+
+  * Value type is <<string,string>>
+  * Default value is `nil`
+
+Canonical name of an array field present in the event containing the names of fields to send to Influxdb 
+as tags instead of fields. Tags are only sent when present in `data_points` or if `use_hash_field_for_data_points` 
+is specified or if `use_event_fields_for_data_points` is `true`.
+This configuration parameter overrides the behavior specified by `send_as_tags`.
+ 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl` 
 
@@ -257,6 +271,15 @@ only useful when overriding the time value
   * Default value is `false`
 
 Automatically use fields from the event as the data points sent to Influxdb
+
+[id="plugins-{type}s-{plugin}-use_hash_field_for_data_points"]
+===== `use_hash_field_for_data_points`
+
+  * Value type is <<string,string>>
+  * Default value is `nil`
+
+Specify a canonical name of a hash field present in the event containing the data points sent to Influxdb
+This configuration parameter overrides the behavior specified by `use_event_fields_for_data_points`.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 

--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -1,31 +1,48 @@
+# -*- encoding: utf-8 -*-
+# stub: logstash-output-influxdb 5.0.5 ruby lib
+
 Gem::Specification.new do |s|
-  s.name            = 'logstash-output-influxdb'
-  s.version         = '5.0.5'
-  s.licenses        = ['Apache License (2.0)']
-  s.summary         = "Writes metrics to InfluxDB"
-  s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
-  s.authors         = ["Elastic"]
-  s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
-  s.require_paths = ["lib"]
+  s.name = "logstash-output-influxdb".freeze
+  s.version = "5.0.6"
 
-  # Files
-  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "logstash_group" => "output", "logstash_plugin" => "true" } if s.respond_to? :metadata=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Elastic".freeze]
+  s.date = "2019-08-22"
+  s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program".freeze
+  s.email = "info@elastic.co".freeze
+  s.homepage = "http://www.elastic.co/guide/en/logstash/current/index.html".freeze
+  s.licenses = ["Apache License (2.0)".freeze]
+  s.rubygems_version = "2.7.9".freeze
+  s.summary = "Writes metrics to InfluxDB".freeze
 
-  # Tests
-  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+  s.installed_by_version = "2.7.9" if s.respond_to? :installed_by_version
 
-  # Special flag to let us know this is actually a logstash plugin
-  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
 
-  # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-
-  s.add_runtime_dependency 'stud'
-  s.add_runtime_dependency 'influxdb' , ">= 0.3", "<= 0.3.99"
-
-  s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'logstash-input-generator'
-  s.add_development_dependency 'logstash-filter-kv'
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<logstash-core-plugin-api>.freeze, [">= 1.60", "<= 2.99"])
+      s.add_runtime_dependency(%q<stud>.freeze, [">= 0"])
+      s.add_runtime_dependency(%q<influxdb>.freeze, [">= 0.3", "<= 0.3.99"])
+      s.add_development_dependency(%q<logstash-devutils>.freeze, [">= 0"])
+      s.add_development_dependency(%q<logstash-input-generator>.freeze, [">= 0"])
+      s.add_development_dependency(%q<logstash-filter-kv>.freeze, [">= 0"])
+    else
+      s.add_dependency(%q<logstash-core-plugin-api>.freeze, [">= 1.60", "<= 2.99"])
+      s.add_dependency(%q<stud>.freeze, [">= 0"])
+      s.add_dependency(%q<influxdb>.freeze, [">= 0.3", "<= 0.3.99"])
+      s.add_dependency(%q<logstash-devutils>.freeze, [">= 0"])
+      s.add_dependency(%q<logstash-input-generator>.freeze, [">= 0"])
+      s.add_dependency(%q<logstash-filter-kv>.freeze, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<logstash-core-plugin-api>.freeze, [">= 1.60", "<= 2.99"])
+    s.add_dependency(%q<stud>.freeze, [">= 0"])
+    s.add_dependency(%q<influxdb>.freeze, [">= 0.3", "<= 0.3.99"])
+    s.add_dependency(%q<logstash-devutils>.freeze, [">= 0"])
+    s.add_dependency(%q<logstash-input-generator>.freeze, [">= 0"])
+    s.add_dependency(%q<logstash-filter-kv>.freeze, [">= 0"])
+  end
 end
-

--- a/spec/outputs/influxdb_spec.rb
+++ b/spec/outputs/influxdb_spec.rb
@@ -205,6 +205,35 @@ describe LogStash::Outputs::InfluxDB do
 
   end
 
+  context "read data-points/tags from speicifc event fields" do
+
+    let(:config) do
+    {
+      "host" => "localhost",
+      "measurement" => "my_series",
+      "allow_time_override" => true,
+      "use_event_fields_for_data_points" => true,
+      "use_hash_field_for_data_points" => "[pts]",
+      "send_array_field_as_tags" => "[tags]",
+    }
+    end
+
+    before do
+      subject.register
+      allow(subject).to receive(:dowrite).with(result, "statistics")
+      subject.receive(event)
+      subject.close
+    end
+
+    let(:event) {LogStash::Event.new("time" => 22,"pts" => {"foo" => "bar","fee" =>"buzz"}, "tags" => ["foo"], "type" => "generator")}
+    let(:result) {[{:series=>"my_series", :timestamp=>22, :tags=>{"foo"=>"true"}, :values=>{"foo"=>"bar","fee"=>"buzz"}}]}
+
+    it "should use the hash field entries as the data points and array field as tags" do
+      expect(subject).to have_received(:dowrite).with(result, "statistics")
+    end
+
+  end
+
   context "when fields are coerced to numerics" do
 
     let(:config) do


### PR DESCRIPTION
This allows specifying document fields to be use for data-points/tag set.