### PR TITLE
Fix typos

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -270,4 +270,3 @@ The user who has access to the named database
 include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:
-

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -270,3 +270,4 @@ The user who has access to the named database
 include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:
+

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -104,7 +104,7 @@ currently supported datatypes are `integer` and `float`
   * Default value is `{}`
 
 Hash of key/value pairs representing data points to send to the named database
-Example: `{'column1' => 'value1', 'column2' => 'value2'}`
+Example: `{'column1' => 'value1' 'column2' => 'value2'}`
 
 Events for the same measurement will be batched together where possible
 Both keys and values support sprintf formatting

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -230,7 +230,7 @@ The retention policy to use
 An array containing the names of fields to send to Influxdb as tags instead 
 of fields. Influxdb 0.9 convention is that values that do not change every
 request should be considered metadata and given as tags. Tags are only sent when
-present in `data_points` or if `user_event_fields_for_data_points` is `true`. 
+present in `data_points` or if `use_event_fields_for_data_points` is `true`. 
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl` 


### PR DESCRIPTION
- The [hash](https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#hash) datatype is separated by spaces, not commas
- Fix property name for `use_event_fields_for_data_points`

