### PR TITLE
Remove comma from data_points as it fails to send data to influxdb

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -104,7 +104,7 @@ currently supported datatypes are `integer` and `float`
   * Default value is `{}`
 
 Hash of key/value pairs representing data points to send to the named database
-Example: `{'column1' => 'value1', 'column2' => 'value2'}`
+Example: `{'column1' => 'value1' 'column2' => 'value2'}`
 
 Events for the same measurement will be batched together where possible
 Both keys and values support sprintf formatting


### PR DESCRIPTION
data_points fails to send data if comma is passed as key value separator. Based on the definition of data type 'Hash' there shouldn't be comma between multiple fields.

https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#hash

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
