### PR TITLE
Remove the comma to match the hash data type. When a comma is passed as a separator, logstash fails to sent data_points to influx

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -104,7 +104,7 @@ currently supported datatypes are `integer` and `float`
   * Default value is `{}`
 
 Hash of key/value pairs representing data points to send to the named database
-Example: `{'column1' => 'value1', 'column2' => 'value2'}`
+Example: `{'column1' => 'value1' 'column2' => 'value2'}`
 
 Events for the same measurement will be batched together where possible
 Both keys and values support sprintf formatting


### PR DESCRIPTION
Remove the comma to match the hash data type. When a comma is passed as a separator, logstash fails to sent data_points to influx

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
